### PR TITLE
Removing php5 and phpmyadmin from the database server.

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -12,5 +12,5 @@
    roles:
     - init
     - mariadb10
-    - php5
-    - phpmyadmin
+#    - php5
+#    - phpmyadmin


### PR DESCRIPTION
Reason: DB server with ONLY the database service.
